### PR TITLE
OOO Calendar TZ Bugfix

### DIFF
--- a/backends/calendar/controller.js
+++ b/backends/calendar/controller.js
@@ -81,7 +81,6 @@ async function listEvents(auth) {
   const outOfOfficeCalendarId = 'amida-tech.com_9dugut48t480pb4qee57stskjs@group.calendar.google.com';
   
 const calendar = google.calendar({version: 'v3', auth});
-    console.log(startOfDay.toISOString(), endOfDay.toISOString());
   let res = await calendar.events.list({
     calendarId: outOfOfficeCalendarId,
     timeMin: startOfDay.toISOString(),

--- a/backends/calendar/controller.js
+++ b/backends/calendar/controller.js
@@ -4,10 +4,7 @@ const fs = require('fs');
 const readline = require('readline');
 const xregexp = require('xregexp')
 const {google} = require('googleapis');
-const dayjs = require('dayjs');
-const advancedFormat = require('dayjs/plugin/advancedFormat');
-
-dayjs.extend(advancedFormat);
+const moment = require('moment-timezone');
 
 // If modifying these scopes, delete token.json.
 const SCOPES = ['https://www.googleapis.com/auth/calendar.readonly'];
@@ -78,14 +75,13 @@ async function listEvents(auth) {
   const returnArray = [];
 
   //constants
-  const startOfDay = new Date();
-  startOfDay.setHours(0,0,0,0);
-  const endOfDay = new Date();
-  endOfDay.setHours(23,59,59,0);
+  const startOfDay = moment().tz('America/New_York').startOf('day');
+  const endOfDay = startOfDay.clone().endOf('day');
   const maxResults = 100;
   const outOfOfficeCalendarId = 'amida-tech.com_9dugut48t480pb4qee57stskjs@group.calendar.google.com';
   
 const calendar = google.calendar({version: 'v3', auth});
+    console.log(startOfDay.toISOString(), endOfDay.toISOString());
   let res = await calendar.events.list({
     calendarId: outOfOfficeCalendarId,
     timeMin: startOfDay.toISOString(),
@@ -103,8 +99,8 @@ const calendar = google.calendar({version: 'v3', auth});
       let eventObject = {};
       eventObject.start = e.start.dateTime || e.start.date;
       eventObject.end = e.end.dateTime || e.end.date;
-      eventObject.humanEnd = dayjs(eventObject.end).format('MMM Do');
-      eventObject.machineEnd = dayjs(eventObject.end).format('X'); // unix timestamp for sorting
+      eventObject.humanEnd = moment(eventObject.end).format('MMM Do');
+      eventObject.machineEnd = moment(eventObject.end).format('X'); // unix timestamp for sorting
       eventObject.summary = e.summary;
 
       let regExec = xregexp.exec(e.summary, /(\w*)(?:'s)? (PTO|OOO|remote)/i)

--- a/backends/calendar/package-lock.json
+++ b/backends/calendar/package-lock.json
@@ -613,11 +613,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "dayjs": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.14.tgz",
-      "integrity": "sha512-AVhDmRTe541iWirnoeFSSDDGvCT6HWaNQ4z2WmmzXMGZj6ph6ydao2teKq/eUtR43GPJXlYFD+C/SotG1P9wUQ=="
-    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -2350,6 +2345,19 @@
             "is-plain-object": "^2.0.4"
           }
         }
+      }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "moment-timezone": {
+      "version": "0.5.25",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.25.tgz",
+      "integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
+      "requires": {
+        "moment": ">= 2.9.0"
       }
     },
     "ms": {

--- a/backends/calendar/package.json
+++ b/backends/calendar/package.json
@@ -24,9 +24,10 @@
   ],
   "dependencies": {
     "@rimiti/express-async": "^1.2.0",
-    "dayjs": "^1.8.14",
     "express": "^4.16.4",
     "googleapis": "^39.2.0",
+    "moment": "^2.24.0",
+    "moment-timezone": "^0.5.25",
     "request": "^2.88.0",
     "xregexp": "^4.2.4"
   },


### PR DESCRIPTION
### Issue
The OOO service queries google calendar for all events occurring today by passing in 'today at 00:00' and 'today at 23:59' query range dates to the GCal API. This works great when the system timezone is set to local time, however deploying this to the TV (where system time is UTC) broke things. An OOO that runs through 5/29 ends at 5/29 23:59 EDT. However, this is 5/30 04:59 UTC, so the OOO would show up on the TV as ending 5/30.

### Fix
This PR updates the query to always use Eastern time date ranges. Note: I had to switch from `dayjs` (lightweight API-compatible `moment` alternative) to `moment` to get timezone support.

### To Test
Run the calendar service on your local machine. Come look at the 7th floor TV and make sure the onscreen calendar matches the results you get from `localhost:3000/gcal`.