### PR TITLE
Automatically refresh OOO/k8s views in frontend

### DIFF
--- a/frontend/src/components/GCal/GCal.vue
+++ b/frontend/src/components/GCal/GCal.vue
@@ -42,6 +42,7 @@ export default {
   },
   async mounted() {
     this.fetchGCal();
+    setInterval(this.fetchGCal, 30000);
   },
   methods: {
     ...mapActions(['fetchGCal']),

--- a/frontend/src/components/k8sView.vue
+++ b/frontend/src/components/k8sView.vue
@@ -61,6 +61,7 @@ export default {
   },
   async mounted() {
     this.fetchK8s();
+    setInterval(this.fetchK8s, 30000);
   },
   methods: {
     ...mapActions(['fetchK8s', 'fetchCommits']),


### PR DESCRIPTION
### Issue
All transit views (including weather) were automatically updating in the frontend, but OOO/k8s views were not. This meant we were getting week-old OOOs showing up on the TV.

### Fix
Use `setInterval` to refresh OOO/k8s data every 30 seconds with `setInterval`, same as Grant's code for transit.

### To Test
Run the frontend and open up your favorite browser debugging tool. Take a look at outgoing network requests and verify that every ~30s you see:
* A request to `(localhost:3000)/gcal`
* A request to `(localhost:3001)/deployments`