### PR TITLE
Enable autologin

### DIFF
--- a/kiosk/install.sh
+++ b/kiosk/install.sh
@@ -145,6 +145,7 @@ sudo systemctl start amida-dashboard-k8s >> install.log 2>&1
 if [ "$KIOSK_MODE" = true ]; then
 	echo
 	echo "Setting up browser autostart"
+    envsubst < share/50-autologin.conf | sudo tee /etc/lightdm/lightdm.conf.d/50-autologin.conf >> install.log
 	sudo mkdir -p $HOMEDIR/.config/autostart
 	# autostart a chrome window in kiosk mode pointing to the dashboard
 	sudo cp kiosk/share/dashboard.desktop $HOMEDIR/.config/autostart/dashboard.desktop

--- a/kiosk/share/50-autologin.conf
+++ b/kiosk/share/50-autologin.conf
@@ -1,0 +1,3 @@
+[SeatDefaults]
+autologin-user=${USER}
+autologin-user-timeout=0


### PR DESCRIPTION
This reverts commit b610f110cf4ed506968db937587e9aa80cab8f76. Now we're using a k8s service user with read-only perms, no security issues with autologin to nonprivileged user.